### PR TITLE
Adding Support for Razer BlackShark V2 Pro (Both the 2020 and 2023 versions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Much of this code is adapted from other works, credit below:
 * HyperPolling Wireless Dongle
 * Viper Ultimate 
 * Mouse Dock Pro
+* BlackShark V2 Pro RZ04-0322 (2020 Version)
+* BlackShark V2 Pro RZ04-0453 (2023 Version)
 
 ## Transaction IDs
 * https://github.com/openrazer/openrazer/blob/master/driver/razermouse_driver.c

--- a/src/main.js
+++ b/src/main.js
@@ -132,7 +132,7 @@ const RazerProducts = {
         transactionId: 0x3f
     },
     0x0528: {
-        name: 'Razer Blackshark V2 Pro RZ04-03220',
+        name: 'Razer Blackshark V2 Pro RZ04-0322',
         transactionId: 0x3f
     },
 };


### PR DESCRIPTION
I own the 2023 version but also pulled the product ID for the 2020 version from https://github.com/openrazer/openrazer/issues/1280. 