### PR TITLE
add mutex locking for openrgb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "razerbatterytaskbar",
-  "version": "1.0.1",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "razerbatterytaskbar",
-      "version": "1.0.1",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.0",
+        "koffi": "^2.8.11",
         "usb": "^2.6.0"
       },
       "devDependencies": {
@@ -3668,6 +3669,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/koffi": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.8.11.tgz",
+      "integrity": "sha512-wrWaW6DJVFis7Qlsh4YDwObrzE/Jynu8pWC3W+0B3d4kv5BFbpPFWEzg4QYGjF+tOA/kpzol8n5o5j4+SGMbQA==",
+      "hasInstallScript": true
     },
     "node_modules/listr2": {
       "version": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",
+    "koffi": "^2.8.11",
     "usb": "^2.6.0"
   },
   "devDependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -10,10 +10,13 @@ const {
 } = require('electron');
 if (require('electron-squirrel-startup')) app.quit();
 
+const mutex = require('./mutex.js');
+
 const path = require('path');
 const rootPath = app.getAppPath();
 let tray;
 let batteryCheckInterval;
+let mutexHandle;
 
 app.whenReady().then(() => {
     const icon = nativeImage.createFromPath(path.join(rootPath, 'src/assets/battery_0.png'));
@@ -22,6 +25,9 @@ app.whenReady().then(() => {
     const contextMenu = Menu.buildFromTemplate([
         { label: 'Quit', type: 'normal', click: QuitClick }
     ]);
+
+    const mutexName = 'Global\\RazerLinkReadWriteGuardMutex';
+    mutexHandle = mutex.createNamedMutex(mutexName);
 
     batteryCheckInterval = setInterval(() => {
         SetTrayDetails(tray);
@@ -32,6 +38,10 @@ app.whenReady().then(() => {
     tray.setContextMenu(contextMenu);
     tray.setToolTip('Searching for device');
     tray.setTitle('Razer battery life');
+
+    tray.on("double-click", () => {
+        SetTrayDetails(tray);
+    })
 })
 
 function SetTrayDetails(tray) {
@@ -53,6 +63,10 @@ function GetBatteryIconPath(val) {
 
 function QuitClick() {
     clearInterval(batteryCheckInterval);
+
+    mutex.closeMutexHandle(mutexHandle);
+    console.log('Mutex handle closed');
+
     if (process.platform !== 'darwin') app.quit();
 };
 
@@ -175,8 +189,30 @@ async function GetMouse() {
         throw new Error('No Razer device found on system');
     }
 };
+
 async function GetBattery() {
     try {
+        console.log('Mutex created');
+
+        mutex.acquireMutex(mutexHandle);
+        console.log('Mutex acquired');
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Perform your protected operation here
+        return await GetBatteryLocked();
+    } catch (error) {
+        console.error(error);
+    } finally {
+        if (mutexHandle) {
+            mutex.releaseMutex(mutexHandle);
+            console.log('Mutex released');
+        }
+    }
+}
+
+async function GetBatteryLocked() {
+    try{
         const mouse = await GetMouse();
 
         const msg = GetMessage(mouse);
@@ -211,4 +247,4 @@ async function GetBattery() {
     } catch (error) {
         console.error(error);
     }
-};
+}

--- a/src/mutex.js
+++ b/src/mutex.js
@@ -1,0 +1,85 @@
+const koffi = require('koffi');
+
+const isWin = process.platform === "win32";
+if (!isWin){
+    module.exports = {
+        // Function to create a named mutex
+        createNamedMutex: function (name) {
+            return 0;
+        },
+
+        // Function to acquire the mutex
+        acquireMutex: function (mutexHandle, timeout = 2000) {
+            return true
+        },
+
+        // Function to release the mutex
+        releaseMutex: function (mutexHandle) {
+        },
+
+        // Function to close the mutex handle
+        closeMutexHandle: function (mutexHandle) {
+        },
+    }
+}
+
+// Load the shared library
+const kernel32 = koffi.load('kernel32.dll');
+
+const PackedStruct = koffi.pack('SECURITY_ATTRIBUTES', {
+    nLength: koffi.types.long,  //DWORD
+    lpSecurityDescriptor: 'void *',    //LPVOID
+    bInheritHandle: 'long',  //BOOL
+});
+
+// Define the necessary Windows API functions
+const CreateMutexW = kernel32.func('int CreateMutexW(SECURITY_ATTRIBUTES lpMutexAttributes, bool bInitialOwner, str lpName)');
+const WaitForSingleObject = kernel32.func('long WaitForSingleObject(int hHandle, long dwMilliseconds)');
+const ReleaseMutex = kernel32.func('bool ReleaseMutex(int hMutex)');
+const CloseHandle = kernel32.func('bool CloseHandle(int hObject)');
+
+// Define constants
+const WAIT_OBJECT_0 = 0x00000000;
+const WAIT_TIMEOUT = 0x00000102;
+
+module.exports = {
+    // Function to create a named mutex
+    createNamedMutex: function (name) {
+        const mutexName = Buffer.from(name, 'utf16le');
+        const mutexHandle = CreateMutexW({}, false, mutexName);
+
+
+        if (!mutexHandle) {
+            throw new Error('Failed to create mutex');
+        }
+        console.log(mutexHandle)
+        return mutexHandle;
+    },
+
+    // Function to acquire the mutex
+    acquireMutex: function (mutexHandle, timeout = 2000) {
+        const result = WaitForSingleObject(mutexHandle, timeout);
+        if (result === WAIT_OBJECT_0) {
+            return true;
+        } else if (result === WAIT_TIMEOUT) {
+            throw new Error('Failed to acquire mutex: timeout');
+        } else {
+            throw new Error('Failed to acquire mutex');
+        }
+    },
+
+    // Function to release the mutex
+    releaseMutex: function (mutexHandle) {
+        if (!ReleaseMutex(mutexHandle)) {
+            throw new Error('Failed to release mutex');
+        }
+    },
+
+    // Function to close the mutex handle
+    closeMutexHandle: function (mutexHandle) {
+        if (!CloseHandle(mutexHandle)) {
+            throw new Error('Failed to close mutex handle');
+        }
+    },
+}
+


### PR DESCRIPTION
This PR adds mutex locking so that other softwares can play nicely. This is done especially for OpenRGB

Mutex change pr on OpenRGB:
https://gitlab.com/CalcProgrammer1/OpenRGB/-/merge_requests/2426

Implementation uses Windows calls, on linux the functions are empty